### PR TITLE
Fixes wrong return type in systray_linux.c.

### DIFF
--- a/systray_linux.c
+++ b/systray_linux.c
@@ -34,7 +34,7 @@ int nativeLoop(void) {
 	global_temp_icon_file_names = g_array_new(TRUE, FALSE, sizeof(char*));
 	systray_ready();
 	gtk_main();
-	return;
+	return EXIT_SUCCESS;
 }
 
 // runs in main thread, should always return FALSE to prevent gtk to execute it again


### PR DESCRIPTION
This pull request contains a small bugfix for the systray_linux.c file. The return type of the nativeLoop method is defined as integer but implemented as void. This causes a compilation error, which also prevents `go get github.com/getlantern/systray`.

The bugfix sets the return value to EXIT_SUCCESS, which is the analogue behaviour to the systray_darwin.m implementation.