### PR TITLE
Revert "Use templated icons for the menu bar in macOS"

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -159,7 +159,6 @@ void runInMainThread(SEL method, id object) {
 void setIcon(const char* iconBytes, int length) {
   NSData* buffer = [NSData dataWithBytes: iconBytes length:length];
   NSImage *image = [[NSImage alloc] initWithData:buffer];
-  image.template = YES;
   [image setSize:NSMakeSize(16, 16)];
   runInMainThread(@selector(setIcon:), (id)image);
 }


### PR DESCRIPTION
Apologies, this reverts getlantern/systray#46 because of comments in #45 about breaking existing macos tray icons that depend on color.

A better approach would be to extend the API with an additional method SetTemplateIcon instead of changing setIcon.