### PR TITLE
Add support for click event in Windows

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -16,6 +16,8 @@ import (
 )
 
 var (
+	// ClickedCh is the channel which will be notified when the systray icon is clicked
+	ClickedCh  = make(chan struct{})
 	hasStarted = int64(0)
 	hasQuit    = int64(0)
 )
@@ -177,5 +179,13 @@ func systrayMenuItemSelected(id int32) {
 	case item.ClickedCh <- struct{}{}:
 	// in case no one waiting for the channel
 	default:
+	}
+}
+
+func systrayClicked() {
+	select {
+	case ClickedCh <- struct{}{}:
+	default:
+		showMenu()
 	}
 }

--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -19,6 +19,9 @@ func nativeLoop() {
 	C.nativeLoop()
 }
 
+func showMenu() {
+}
+
 func quit() {
 	C.quit()
 }

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -254,8 +254,10 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		systrayExit()
 	case t.wmSystrayMessage:
 		switch lParam {
-		case WM_RBUTTONUP, WM_LBUTTONUP:
+		case WM_RBUTTONUP:
 			t.showMenu()
+		case WM_LBUTTONUP:
+			systrayClicked()
 		}
 	case t.wmTaskbarCreated: // on explorer.exe restarts
 		t.nid.add()
@@ -608,6 +610,10 @@ func nativeLoop() {
 			pDispatchMessage.Call(uintptr(unsafe.Pointer(m)))
 		}
 	}
+}
+
+func showMenu() {
+	wt.showMenu()
 }
 
 func quit() {


### PR DESCRIPTION
This adds support for hooking into the left-click event on the systray icon in Windows. It adds a global ClickedCh channel, similar to the menu item channel. If there are no receivers it will open the menu as it currently does. If there is a receiver, then the event is passed through the channel.

I looked into adding similar functionality for Linux. I could hook into the click event (by listening to about-to-show signal on the menu). However i could not find a way to prevent the menu from loading, so the behavior would be different. Not sure if the support would be useful, but i can submit as well if it would be.

Haven't looked at Mac support yet, but may be able to later this week. I'm not sure that overriding left-click behavior would be desirable on Mac/Linux, however in the case of Windows it's not common to show a menu on left-click so i think this PR may be reasonable.