### PR TITLE
Updated macOS implementation to avoid depricated calls

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -64,15 +64,15 @@
 }
 
 - (void)setIcon:(NSImage *)image {
-  [statusItem setImage:image];
+  statusItem.button.image = image;
 }
 
 - (void)setTitle:(NSString *)title {
-  [statusItem setTitle:title];
+  statusItem.button.title = title;
 }
 
 - (void)setTooltip:(NSString *)tooltip {
-  [statusItem setToolTip:tooltip];
+  statusItem.button.toolTip = tooltip;
 }
 
 - (IBAction)menuHandler:(id)sender
@@ -102,9 +102,9 @@
     [menuItem setEnabled:TRUE];
   }
   if (item->checked == 1) {
-    [menuItem setState:NSOnState];
+    [menuItem setState:NSControlStateValueOn];
   } else {
-    [menuItem setState:NSOffState];
+    [menuItem setState:NSControlStateValueOff];
   }
 }
 


### PR DESCRIPTION
Fixed a few calls that were throwing warning messages when compiling systray on macOS Mojave.

Errors in case:
```
# github.com/getlantern/systray
systray_darwin.m:67:15: warning: 'setImage:' is deprecated: first deprecated in macOS 10.14 - Use the receiver's button.image instead [-Wdeprecated-declarations]
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSStatusItem.h:85:39: note: property 'image' is declared deprecated here
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSStatusItem.h:85:39: note: 'setImage:' has been explicitly marked deprecated here
systray_darwin.m:71:15: warning: 'setTitle:' is deprecated: first deprecated in macOS 10.14 - Use the receiver's button.title instead [-Wdeprecated-declarations]
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSStatusItem.h:83:38: note: property 'title' is declared deprecated here
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSStatusItem.h:83:38: note: 'setTitle:' has been explicitly marked deprecated here
systray_darwin.m:75:15: warning: 'setToolTip:' is deprecated: first deprecated in macOS 10.14 - Use the receiver's button.toolTip instead [-Wdeprecated-declarations]
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSStatusItem.h:89:38: note: property 'toolTip' is declared deprecated here
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSStatusItem.h:89:38: note: 'setToolTip:' has been explicitly marked deprecated here
systray_darwin.m:105:24: warning: 'NSOnState' is deprecated: first deprecated in macOS 10.14 [-Wdeprecated-declarations]
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSCell.h:80:34: note: 'NSOnState' has been explicitly marked deprecated here
systray_darwin.m:107:24: warning: 'NSOffState' is deprecated: first deprecated in macOS 10.14 [-Wdeprecated-declarations]
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSCell.h:79:34: note: 'NSOffState' has been explicitly marked deprecated here
```
