### PR TITLE
linux: delete temp files as soon as they are not needed

### DIFF
--- a/systray_linux.c
+++ b/systray_linux.c
@@ -48,9 +48,16 @@ void _unlink_temp_file() {
 
 // runs in main thread, should always return FALSE to prevent gtk to execute it again
 gboolean do_set_icon(gpointer data) {
-	GBytes* bytes = (GBytes*)data;
 	_unlink_temp_file();
-	strcpy(temp_file_name, "/tmp/systray_XXXXXX");
+	char *tmpdir = getenv("TMPDIR");
+	if (NULL == tmpdir) {
+		tmpdir = "/tmp";
+	}
+	strncpy(temp_file_name, tmpdir, PATH_MAX-1);
+	strncat(temp_file_name, "/systray_XXXXXX", PATH_MAX-1);
+	temp_file_name[PATH_MAX-1] = '\0';
+
+	GBytes* bytes = (GBytes*)data;
 	int fd = mkstemp(temp_file_name);
 	if (fd == -1) {
 		printf("failed to create temp icon file %s: %s\n", temp_file_name, strerror(errno));

--- a/systray_linux.c
+++ b/systray_linux.c
@@ -8,8 +8,7 @@
 static AppIndicator *global_app_indicator;
 static GtkWidget *global_tray_menu = NULL;
 static GList *global_menu_items = NULL;
-// Keep track of all generated temp files to remove when app quits
-static GArray *global_temp_icon_file_names = NULL;
+static char temp_file_name[PATH_MAX] = "";
 
 typedef struct {
 	GtkWidget *menu_item;
@@ -31,24 +30,32 @@ int nativeLoop(void) {
 	app_indicator_set_status(global_app_indicator, APP_INDICATOR_STATUS_ACTIVE);
 	global_tray_menu = gtk_menu_new();
 	app_indicator_set_menu(global_app_indicator, GTK_MENU(global_tray_menu));
-	global_temp_icon_file_names = g_array_new(TRUE, FALSE, sizeof(char*));
 	systray_ready();
 	gtk_main();
 	systray_on_exit();
 	return 0;
 }
 
+void _unlink_temp_file() {
+	if (strlen(temp_file_name) != 0) {
+		int ret = unlink(temp_file_name);
+		if (ret == -1) {
+			printf("failed to remove temp icon file %s: %s\n", temp_file_name, strerror(errno));
+		}
+		temp_file_name[0] = '\0';
+	}
+}
+
 // runs in main thread, should always return FALSE to prevent gtk to execute it again
 gboolean do_set_icon(gpointer data) {
 	GBytes* bytes = (GBytes*)data;
-	char* temp_file_name = malloc(PATH_MAX);
+	_unlink_temp_file();
 	strcpy(temp_file_name, "/tmp/systray_XXXXXX");
 	int fd = mkstemp(temp_file_name);
 	if (fd == -1) {
 		printf("failed to create temp icon file %s: %s\n", temp_file_name, strerror(errno));
 		return FALSE;
 	}
-	g_array_append_val(global_temp_icon_file_names, temp_file_name);
 	gsize size = 0;
 	gconstpointer icon_data = g_bytes_get_data(bytes, &size);
 	ssize_t written = write(fd, icon_data, size);
@@ -146,17 +153,7 @@ gboolean do_show_menu_item(gpointer data) {
 
 // runs in main thread, should always return FALSE to prevent gtk to execute it again
 gboolean do_quit(gpointer data) {
-	int i;
-	for (i = 0; i < INT_MAX; ++i) {
-		char * temp_file_name = g_array_index(global_temp_icon_file_names, char*, i);
-		if (temp_file_name == NULL) {
-			break;
-		}
-		int ret = unlink(temp_file_name);
-		if (ret == -1) {
-			printf("failed to remove temp icon file %s: %s\n", temp_file_name, strerror(errno));
-		}
-	}
+	_unlink_temp_file();
 	// app indicator doesn't provide a way to remove it, hide it as a workaround
 	app_indicator_set_status(global_app_indicator, APP_INDICATOR_STATUS_PASSIVE);
 	gtk_main_quit();


### PR DESCRIPTION
Stop generating one file in /tmp for each icon change. Let's move the
clean up to the set icon instead of waiting for the quit clean up.
~Unlink will remove the file from /tmp, but app_indicator will hold a
descriptor until it finishes with it.~