### PR TITLE
Fix bug causing duplicated menu items on windows

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -49,12 +49,14 @@ func onReady() {
 		mQuit.SetIcon(icon.Data)
 
 		systray.AddSeparator()
-		mToggle := systray.AddMenuItem("Toggle", "Toggle the Quit button")
+		mShowHide := systray.AddMenuItem("Hide", "Hide a few menu items")
 		shown := true
+		changed := 0
 		for {
 			select {
 			case <-mChange.ClickedCh:
-				mChange.SetTitle("I've Changed")
+				changed++
+				mChange.SetTitle(fmt.Sprintf("I've Changed %d time(s)", changed))
 			case <-mChecked.ClickedCh:
 				if mChecked.Checked() {
 					mChecked.Uncheck()
@@ -68,14 +70,18 @@ func onReady() {
 				mEnabled.Disable()
 			case <-mUrl.ClickedCh:
 				open.Run("https://www.getlantern.org")
-			case <-mToggle.ClickedCh:
+			case <-mShowHide.ClickedCh:
 				if shown {
 					mQuitOrig.Hide()
 					mEnabled.Hide()
+					mShowHide.SetTitle("Show")
+					mShowHide.SetTooltip("Show previously hidden menu items")
 					shown = false
 				} else {
 					mQuitOrig.Show()
 					mEnabled.Show()
+					mShowHide.SetTitle("Hide")
+					mShowHide.SetTooltip("Hide a few menu items")
 					shown = true
 				}
 			case <-mQuit.ClickedCh:

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -462,26 +462,21 @@ func (t *winTray) addOrUpdateMenuItem(menuId int32, title string, disabled, chec
 	}
 	mi.Size = uint32(unsafe.Sizeof(mi))
 
-	// The return value is the identifier of the specified menu item.
-	// If the menu item identifier is NULL or if the specified item opens a submenu, the return value is -1.
-	// If the given menu identifier is not found (becase we deleted the menu item when hiding it),
-	// the call will return the next integer that is available as an existing menu item.
-	res, _, err := pGetMenuItemID.Call(uintptr(t.menu), uintptr(menuId))
-	if int32(res) == -1 || int32(res) != menuId {
+	// We set the menu item info based on the menuID
+	res, _, err := pSetMenuItemInfo.Call(
+		uintptr(t.menu),
+		uintptr(menuId),
+		0,
+		uintptr(unsafe.Pointer(&mi)),
+	)
+	if res == 0 {
+		// We insert the menu item using the menuID as a position. This is
+		// important because hidden items will end up here when shown again, so
+		// this ensures that their position stays consistent.
 		res, _, err = pInsertMenuItem.Call(
 			uintptr(t.menu),
 			uintptr(menuId),
 			1,
-			uintptr(unsafe.Pointer(&mi)),
-		)
-		if res == 0 {
-			return err
-		}
-	} else {
-		res, _, err = pSetMenuItemInfo.Call(
-			uintptr(t.menu),
-			uintptr(menuId),
-			0,
 			uintptr(unsafe.Pointer(&mi)),
 		)
 		if res == 0 {


### PR DESCRIPTION
It reverts the logic of to the old way [in the DLL version](https://github.com/getlantern/systray/blob/62af9eb8030c168caa78856c967e6d2c4a7d813e/systray/systray/systray.cpp#L205). The bug it fixed can be shown by running the updated example. Note that duplicated menu items after hiding and showing certain menu items.

<img width="158" alt="image" src="https://user-images.githubusercontent.com/22091642/47250421-940a5500-d3d5-11e8-89eb-129d6d46bad0.png">
