### PR TITLE
Support macOS older than 10.13

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -1,6 +1,14 @@
 #import <Cocoa/Cocoa.h>
 #include "systray.h"
 
+#ifndef NSControlStateValueOff
+  #define NSControlStateValueOff NSOffState
+#endif
+
+#ifndef NSControlStateValueOn
+  #define NSControlStateValueOn NSOnState
+#endif
+
 @interface MenuItem : NSObject
 {
   @public


### PR DESCRIPTION
`NSControlStateValueOff` and `NSControlStateValueOn` available since 10.13