### PR TITLE
Fix bad-looking system tray icon in Windows

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -183,6 +183,7 @@ type winTray struct {
 func (t *winTray) setIcon(src string) error {
 	const IMAGE_ICON = 1               // Loads an icon
 	const LR_LOADFROMFILE = 0x00000010 // Loads the stand-alone image from the file
+	const LR_DEFAULTSIZE = 0x00000040  // Loads default-size icon for windows(16 x 16) if cx, cy are set to zero
 	const NIF_ICON = 0x00000002
 
 	// Save and reuse handles of loaded images
@@ -196,9 +197,9 @@ func (t *winTray) setIcon(src string) error {
 			0,
 			uintptr(unsafe.Pointer(srcPtr)),
 			IMAGE_ICON,
-			64,
-			64,
-			LR_LOADFROMFILE,
+			0,
+			0,
+			LR_LOADFROMFILE|LR_DEFAULTSIZE,
 		)
 		if res == 0 {
 			return err


### PR DESCRIPTION
Hello, I have noticed that system tray icon on windows looks bad if .ico file contains multiple sizes(not only 32x32 as in example), suppose it scales from 64x64 to 16x16 in system tray in current realization. This PR fixes this issue.