### PR TITLE
Attempt to fix https://github.com/getlantern/systray/issues/75

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -1,12 +1,16 @@
 #import <Cocoa/Cocoa.h>
 #include "systray.h"
 
-#ifndef NSControlStateValueOff
-  #define NSControlStateValueOff NSOffState
-#endif
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_14
 
-#ifndef NSControlStateValueOn
-  #define NSControlStateValueOn NSOnState
+    #ifndef NSControlStateValueOff
+      #define NSControlStateValueOff NSOffState
+    #endif
+
+    #ifndef NSControlStateValueOn
+      #define NSControlStateValueOn NSOnState
+    #endif
+
 #endif
 
 @interface MenuItem : NSObject


### PR DESCRIPTION
I think I may have solved issue #75 with a simply macro by updating `systray_darwin.m` to this:

```
#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_14
    #ifndef NSControlStateValueOff
      #define NSControlStateValueOff NSOffState
    #endif
    #ifndef NSControlStateValueOn
      #define NSControlStateValueOn NSOnState
    #endif
#endif
```

As I am not an objective C programmer so I am not certain this is a proper fix, but it seems to be working on my end thus far.  Let me know if this works for you?