### PR TITLE
systray_darwin.m: Compare Mac OS min version with value instead of macro

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -1,7 +1,7 @@
 #import <Cocoa/Cocoa.h>
 #include "systray.h"
 
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_14
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101400
 
     #ifndef NSControlStateValueOff
       #define NSControlStateValueOff NSOffState


### PR DESCRIPTION
I was getting this error building on Mac OS X 10.12:

    $ pwd
    <$GOPATH>/src/github.com/getlantern/systray/example
    $ go run .
    # github.com/getlantern/systray
    systray_darwin.m:132:22: error: use of undeclared identifier 'NSControlStateValueOn'
    systray_darwin.m:134:22: error: use of undeclared identifier 'NSControlStateValueOff'

The `NSControlStateValueOn` and `NSControlStateValueOff` were not
defined because Mac OS versions prior to 10.14 don't define
`__MAC_10_14`.

From `/usr/include/Availability.h`:

> It is also possible to use the *_VERSION_MIN_REQUIRED in source code to make one
> source base that can be compiled to target a range of OS versions.  It is best
> to not use the _MAC_* and __IPHONE_* macros for comparisons, but rather their values.
> That is because you might get compiled on an old OS that does not define a later
> OS version macro, and in the C preprocessor undefined values evaluate to zero
> in expresssions, which could cause the #if expression to evaluate in an unexpected
> way.
>
>     #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
>         // code only compiled when targeting Mac OS X and not iPhone
>         // note use of 1050 instead of __MAC_10_5
>         #if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050
>             // code in here might run on pre-Leopard OS
>         #else
>             // code here can assume Leopard or later
>         #endif
>     #endif

See #75, #92.