### PR TITLE
Fix Deadlock and item ordering in Windows

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -122,7 +122,7 @@ func ShowAppWindow(url string) {
 func addOrUpdateMenuItem(item *MenuItem) {
 	action := actions[item.id]
 	if action == nil {
-		item.id = atomic.AddInt32(&nextActionId, 1)
+		item.id = nextActionId
 		action = walk.NewAction()
 		action.Triggered().Attach(func() {
 			// Ensure there is at least one receiver to prevent deadlock
@@ -138,6 +138,7 @@ func addOrUpdateMenuItem(item *MenuItem) {
 			fail("Unable to add menu item to systray", err)
 		}
 		actions[item.id] = action
+		atomic.AddInt32(&nextActionId, 1)
 	}
 	err := action.SetText(item.title)
 	if err != nil {

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -125,6 +125,13 @@ func addOrUpdateMenuItem(item *MenuItem) {
 		item.id = atomic.AddInt32(&nextActionId, 1)
 		action = walk.NewAction()
 		action.Triggered().Attach(func() {
+			// Ensure there is at least one receiver to prevent deadlock
+			go func() {
+				select {
+				case <-item.ClickedCh:
+				}
+			}()
+
 			item.ClickedCh <- struct{}{}
 		})
 		if err := notifyIcon.ContextMenu().Actions().Add(action); err != nil {


### PR DESCRIPTION
Hi,

This PR addresses two issues raised in #101:

- Ensure all item.ClickCh channels have at least one receiver to avoid deadlocks.

- nextActionId was incrementing too early, resulting in the second added item not being added to the actions map. Ie:
-- Item 0 is assigned to action 1
-- Item 1 is not added (because item 0 was assigned to action 1)