### PR TITLE
Reverted deadlock fix (Affected other receivers)

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -125,13 +125,6 @@ func addOrUpdateMenuItem(item *MenuItem) {
 		item.id = nextActionId
 		action = walk.NewAction()
 		action.Triggered().Attach(func() {
-			// Ensure there is at least one receiver to prevent deadlock
-			go func() {
-				select {
-				case <-item.ClickedCh:
-				}
-			}()
-
 			item.ClickedCh <- struct{}{}
 		})
 		if err := notifyIcon.ContextMenu().Actions().Add(action); err != nil {


### PR DESCRIPTION
Hi,

This PR reverts a change made in PR #103 which originally addressed an issue in #101.

The previous PR ensured every `item.ClickedCh` had at least one receiver assigned. This stopped the application from deadlocking when clicking menu items with no assigned Channel receivers.

However, that change has adversely affected menu items with assigned channel receivers. They are currently not consistently being notified on item clicks. See https://stackoverflow.com/questions/15715605/multiple-goroutines-listening-on-one-channel.

Something more sophisticated would be required to handle item.ClickCh with no assigned receivers. 

Apologies in advance for the previously introduced bug.