### PR TITLE
Support for nested sub-menus on Windows

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -19,7 +19,6 @@ var (
 
 	actions      = make(map[int32]*walk.Action)
 	menus        = make(map[int32]*walk.Menu)
-	nextActionId int32
 
 	okayToClose int32
 )


### PR DESCRIPTION
Related: #99 

Basically took the new changes on `systray.go` files and modified the `systray_windows.go` file to support sub-menus.

Result
![Capture](https://user-images.githubusercontent.com/5497356/69903977-00a99e80-13a1-11ea-826e-76b6a7eea487.PNG)

How to:
![Capture2](https://user-images.githubusercontent.com/5497356/69903979-08694300-13a1-11ea-9dc0-012fe66402ee.PNG)
