### PR TITLE
Systray icon could not be changed dynamically

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -78,7 +78,7 @@ func quit() {
 // for other platforms.
 func SetIcon(iconBytes []byte) {
 	md5 := md5.Sum(iconBytes)
-	filename := fmt.Sprintf("%x", md5) + ".ico"
+	filename := fmt.Sprintf("systray.%x.ico", md5)
 	// First, try to find a previously loaded icon in walk cache
 	icon, err := walk.Resources.Icon(filename)
 	if err != nil {
@@ -160,15 +160,21 @@ func addOrUpdateMenuItem(item *MenuItem) {
 }
 
 func (item *MenuItem) SetIcon(iconBytes []byte) {
-	filename := fmt.Sprintf("systray.%d.ico", item.id)
-	err := ioutil.WriteFile(filename, iconBytes, 0644)
-	if err != nil {
-		fail("Unable to save icon to disk", err)
-	}
-	defer os.Remove(filename)
+	md5 := md5.Sum(iconBytes)
+	filename := fmt.Sprintf("systray.%x.ico", md5)
+	// First, try to find a previously loaded icon in walk cache
 	icon, err := walk.Resources.Image(filename)
 	if err != nil {
-		fail("Unable to load icon", err)
+		// Cache miss, load the icon
+		err := ioutil.WriteFile(filename, iconBytes, 0644)
+		if err != nil {
+			fail("Unable to save icon to disk", err)
+		}
+		defer os.Remove(filename)
+		icon, err = walk.Resources.Image(filename)
+		if err != nil {
+			fail("Unable to load icon", err)
+		}
 	}
 	actions[item.id].SetImage(icon)
 }


### PR DESCRIPTION
There is an issue with the SetIcon method that make impossible to change the systray icon.

This is because when you call the SetIcon method with a different byte array, the icon will get written to a file with a constant name (_systray.ico_).
Then the icon is retrieved from the walk's ResourceManager, but this manager cache the icon according its name (see https://github.com/lxn/walk/blob/master/resourcemanager.go#L88). So the written file will not be read on the second call of SetIcon.

The proposed fix consist to compute the MD5 hash of the icon's byte array and use this hash to uniquely name the temporary icon file. Also the file will not be written if the icon was already loaded in memory.