### PR TITLE
Don't print close reason to console

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -31,7 +31,6 @@ func nativeLoop(title string, width int, height int) {
 		fail("Unable to create main window", err)
 	}
 	mainWindow.Closing().Attach(func(canceled *bool, reason walk.CloseReason) {
-		fmt.Println(reason)
 		// don't close app unless we're actually finished
 		actuallyClose := atomic.LoadInt32(&okayToClose) == 1
 		*canceled = !actuallyClose


### PR DESCRIPTION
Just a small patch to avoid printing the close reason to console.
This is not really an important information, and I think the package should not pollute the main program output for that.