### PR TITLE
Fix panic when resources root path is not the working directory

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -6,6 +6,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"os"
 	"sync/atomic"
 
@@ -79,15 +80,16 @@ func quit() {
 func SetIcon(iconBytes []byte) {
 	md5 := md5.Sum(iconBytes)
 	filename := fmt.Sprintf("systray.%x.ico", md5)
+	iconpath := filepath.Join(walk.Resources.RootDirPath(), filename)
 	// First, try to find a previously loaded icon in walk cache
 	icon, err := walk.Resources.Icon(filename)
 	if err != nil {
 		// Cache miss, load the icon
-		err := ioutil.WriteFile(filename, iconBytes, 0644)
+		err := ioutil.WriteFile(iconpath, iconBytes, 0644)
 		if err != nil {
 			fail("Unable to save icon to disk", err)
 		}
-		defer os.Remove(filename)
+		defer os.Remove(iconpath)
 		icon, err = walk.Resources.Icon(filename)
 		if err != nil {
 			fail("Unable to load icon", err)
@@ -162,15 +164,16 @@ func addOrUpdateMenuItem(item *MenuItem) {
 func (item *MenuItem) SetIcon(iconBytes []byte) {
 	md5 := md5.Sum(iconBytes)
 	filename := fmt.Sprintf("systray.%x.ico", md5)
+	iconpath := filepath.Join(walk.Resources.RootDirPath(), filename)
 	// First, try to find a previously loaded icon in walk cache
 	icon, err := walk.Resources.Image(filename)
 	if err != nil {
 		// Cache miss, load the icon
-		err := ioutil.WriteFile(filename, iconBytes, 0644)
+		err := ioutil.WriteFile(iconpath, iconBytes, 0644)
 		if err != nil {
 			fail("Unable to save icon to disk", err)
 		}
-		defer os.Remove(filename)
+		defer os.Remove(iconpath)
 		icon, err = walk.Resources.Image(filename)
 		if err != nil {
 			fail("Unable to load icon", err)


### PR DESCRIPTION
On Windows, Walk look for the icon in its resources root path, but systray write it to the current working directory.
The current working directory is the default root path, but it may be changed by external code (walk.Resources.SetRootDirPath()).
In this case, systray panic because walk can't find the temporary icon.

This PR fix this issue by writing the icon to the correct resources root path.

My personal use case is to set the resources root path to os.TempDir() to avoid a panic in case of the current working directory is not writable.