### PR TITLE
have a workaround to avoid crash on old macOS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Now look for *Awesome App* in your menu bar!
 
 ## The Webview example
 
-The code under `webview_example` is to demostrate how it can co-exist with other UI elements.
+The code under `webview_example` is to demostrate how it can co-exist with other UI elements. Note that the example doesn't work on macOS versions older than 10.15 Catalina.
 
 ## Platform notes
 

--- a/systray.go
+++ b/systray.go
@@ -78,6 +78,8 @@ func Run(onReady func(), onExit func()) {
 // Register initializes GUI and registers the callbacks but relies on the
 // caller to run the event loop somewhere else. It's useful if the program
 // needs to show other UI elements, for example, webview.
+// To overcome some OS weirdness, On macOS versions before Catalina, calling
+// this does exactly the same as Run().
 func Register(onReady func(), onExit func()) {
 	if onReady == nil {
 		systrayReady = func() {}

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -212,10 +212,18 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 void registerSystray(void) {
   AppDelegate *delegate = [[AppDelegate alloc] init];
   [[NSApplication sharedApplication] setDelegate:delegate];
+  // A workaround to avoid crashing on macOS versions before Catalina. Somehow
+  // SIGSEGV would happen inside AppKit if [NSApp run] is called from a
+  // different function, even if that function is called right after this.
+  if (floor(NSAppKitVersionNumber) <= /*NSAppKitVersionNumber10_14*/ 1671){
+    [NSApp run];
+  }
 }
 
 int nativeLoop(void) {
-  [NSApp run];
+  if (floor(NSAppKitVersionNumber) > /*NSAppKitVersionNumber10_14*/ 1671){
+    [NSApp run];
+  }
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
I figure I'd rather not wasting more time on this crash happening inside the AppKit library after already spending several hours so here's the workaround. It doesn't change anything unless someone wants to have it working with other UI elements like webview, which we've never seen users requested, except ourselves once upon a time.

So what's the problem of the current code running on old macOS versions? It crashes like this:
```
7578:example administrator$ ./example
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7fff8668e4dd]

runtime stack:
runtime.throw(0x430f27e, 0x2a)
	/usr/local/Cellar/go/1.14.3/libexec/src/runtime/panic.go:1116 +0x72
runtime.sigpanic()
	/usr/local/Cellar/go/1.14.3/libexec/src/runtime/signal_unix.go:679 +0x46a

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0x42717f0, 0xc00003cf48, 0x431a028)
	/usr/local/Cellar/go/1.14.3/libexec/src/runtime/cgocall.go:133 +0x5b fp=0xc00003cf18 sp=0xc00003cee0 pc=0x400569b
github.com/getlantern/systray._Cfunc_nativeLoop(0x0)
	_cgo_gotypes.go:114 +0x49 fp=0xc00003cf48 sp=0xc00003cf18 pc=0x426fd59
github.com/getlantern/systray.nativeLoop(...)
	/Users/administrator/go-src/src/github.com/getlantern/systray/systray_nonwindows.go:23
github.com/getlantern/systray.Run(0x431a028, 0x431a010)
	/Users/administrator/go-src/src/github.com/getlantern/systray/systray.go:75 +0x3a fp=0xc00003cf68 sp=0xc00003cf48 pc=0x426f3aa
main.main()
	/Users/administrator/go-src/src/github.com/getlantern/systray/example/main.go:19 +0x39 fp=0xc00003cf88 sp=0xc00003cf68 pc=0x4270949
runtime.main()
	/usr/local/Cellar/go/1.14.3/libexec/src/runtime/proc.go:203 +0x212 fp=0xc00003cfe0 sp=0xc00003cf88 pc=0x4036842
runtime.goexit()
	/usr/local/Cellar/go/1.14.3/libexec/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc00003cfe8 sp=0xc00003cfe0 pc=0x4063391

goroutine 19 [chan receive]:
github.com/getlantern/systray.Register.func2(0xc00010e0c0, 0x431a028)
	/Users/administrator/go-src/src/github.com/getlantern/systray/systray.go:88 +0x34
created by github.com/getlantern/systray.Register
	/Users/administrator/go-src/src/github.com/getlantern/systray/systray.go:87 +0xdd
```

And gdb shows that it happens inside AppKit. 
```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007fff8668e4dd in ?? () from /usr/lib/libobjc.A.dylib
(gdb) bt
#0  0x00007fff8668e4dd in ?? () from /usr/lib/libobjc.A.dylib
#1  0x00007fff8afe6486 in -[NSApplication _doOpenUntitled] () from /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
#2  0x00007fff8afe5fe3 in __58-[NSApplication(NSAppleEventHandling) _handleAEOpenEvent:]_block_invoke () from /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
#3  0x00007fff8afe58fb in -[NSDocumentController(NSInternal) _autoreopenDocumentsIgnoringExpendable:withCompletionHandler:] () from /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
#4  0x00007fff8afe3fbf in -[NSApplication _reopenWindowsAsNecessaryIncludingRestorableState:completionHandler:] () from /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
#5  0x00007fff8afe3d8c in -[NSApplication(NSAppleEventHandling) _handleAEOpenEvent:] () from /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
#6  0x00007fff8afe3843 in -[NSApplication(NSAppleEventHandling) _handleCoreEvent:withReplyEvent:] () from /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
#7  0x00007fff8bc1550d in ?? () from /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
#8  0x0000000000000000 in ?? ()
```