### PR TITLE
Add callback for popup menu open/close in Windows

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -15,6 +15,12 @@ import (
 var (
 	log = golog.LoggerFor("systray")
 
+	// MenuOpenedCh is the channel which will be notified when the popup menu is shown
+	MenuOpenedCh = make(chan struct{})
+
+	// MenuClosedCh is the channel which will be notified when the popup menu is closed
+	MenuClosedCh = make(chan struct{})
+	
 	systrayReady  func()
 	systrayExit   func()
 	menuItems     = make(map[int32]*MenuItem)

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -599,6 +599,11 @@ func (t *winTray) hideMenuItem(menuItemId, parentId uint32) error {
 }
 
 func (t *winTray) showMenu() error {
+	select {
+	case MenuOpenedCh <- struct{}{}:
+	default:
+	}
+
 	const (
 		TPM_BOTTOMALIGN = 0x0020
 		TPM_LEFTALIGN   = 0x0000
@@ -621,6 +626,11 @@ func (t *winTray) showMenu() error {
 	)
 	if res == 0 {
 		return err
+	}
+
+	select {
+	case MenuClosedCh <- struct{}{}:
+	default:
 	}
 
 	return nil


### PR DESCRIPTION
Addresses #121.

This adds support for hooking into the menu open and menu close events in Windows by adding MenuOpenedCh and MenuClosedCh. They can be used like the menu items' ClickedCh. See [here](https://github.com/adriancampos/ha-tray/blob/94e8be317a675fe3829d60f1dd29ca7529c62519/ha-tray.go#L81) for an example.

I haven't looked into adding support for Linux/Mac yet.