### PR TITLE
Does not use the template icon for regular icons

### DIFF
--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -24,7 +24,8 @@ func SetTemplateIcon(templateIconBytes []byte, regularIconBytes []byte) {
 // SetIcon sets the icon of a menu item. Only works on macOS and Windows.
 // iconBytes should be the content of .ico/.jpg/.png
 func (item *MenuItem) SetIcon(iconBytes []byte) {
-	item.SetTemplateIcon(iconBytes, iconBytes)
+	cstr := (*C.char)(unsafe.Pointer(&iconBytes[0]))
+	C.setMenuItemIcon(cstr, (C.int)(len(iconBytes)), C.int(item.id), false)
 }
 
 // SetTemplateIcon sets the icon of a menu item as a template icon (on macOS). On Windows, it


### PR DESCRIPTION
This prevents an issue where you want to control the colour of the icon used. If you need, you need to use a template icon, there's already a function for that: `*MenuItem.SetTemplateIcon()`