### PR TITLE
Allows disabling items in submenu on macOS

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -121,6 +121,7 @@ withParentMenuId: (int)theParentMenuId
       theMenu = parentItem.submenu;
     } else {
       theMenu = [[NSMenu alloc] init];
+      [theMenu setAutoenablesItems:NO];
       [parentItem setSubmenu:theMenu];
     }
   }


### PR DESCRIPTION
Fixes https://github.com/getlantern/systray/issues/169

Per the doc of `NSMenuItem.enabled`:

> This property has no effect unless the menu in which the item will be added or is already a part of has been sent `setAutoenablesItems:NO`.