### PR TITLE
start menu ID with positive, and change the type to uint32

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -17,10 +17,10 @@ var (
 
 	systrayReady  func()
 	systrayExit   func()
-	menuItems     = make(map[int32]*MenuItem)
+	menuItems     = make(map[uint32]*MenuItem)
 	menuItemsLock sync.RWMutex
 
-	currentID = int32(-1)
+	currentID = uint32(0)
 	quitOnce  sync.Once
 )
 
@@ -35,7 +35,7 @@ type MenuItem struct {
 	ClickedCh chan struct{}
 
 	// id uniquely identify a menu item, not supposed to be modified
-	id int32
+	id uint32
 	// title is the text shown on menu item
 	title string
 	// tooltip is the text shown when pointing to menu item
@@ -59,7 +59,7 @@ func (item *MenuItem) String() string {
 func newMenuItem(title string, tooltip string, parent *MenuItem) *MenuItem {
 	return &MenuItem{
 		ClickedCh: make(chan struct{}),
-		id:        atomic.AddInt32(&currentID, 1),
+		id:        atomic.AddUint32(&currentID, 1),
 		title:     title,
 		tooltip:   tooltip,
 		disabled:  false,
@@ -119,7 +119,7 @@ func AddMenuItem(title string, tooltip string) *MenuItem {
 
 // AddSeparator adds a separator bar to the menu
 func AddSeparator() {
-	addSeparator(atomic.AddInt32(&currentID, 1))
+	addSeparator(atomic.AddUint32(&currentID, 1))
 }
 
 // AddSubMenuItem adds a nested sub-menu item with the designated title and tooltip.
@@ -194,7 +194,7 @@ func (item *MenuItem) update() {
 	addOrUpdateMenuItem(item)
 }
 
-func systrayMenuItemSelected(id int32) {
+func systrayMenuItemSelected(id uint32) {
 	menuItemsLock.RLock()
 	item, ok := menuItems[id]
 	menuItemsLock.RUnlock()

--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -55,7 +55,7 @@ func addOrUpdateMenuItem(item *MenuItem) {
 	if item.checked {
 		checked = 1
 	}
-	var parentID int32 = 0
+	var parentID uint32 = 0
 	if item.parent != nil {
 		parentID = item.parent.id
 	}
@@ -69,7 +69,7 @@ func addOrUpdateMenuItem(item *MenuItem) {
 	)
 }
 
-func addSeparator(id int32) {
+func addSeparator(id uint32) {
 	C.add_separator(C.int(id))
 }
 
@@ -97,5 +97,5 @@ func systray_on_exit() {
 
 //export systray_menu_item_selected
 func systray_menu_item_selected(cID C.int) {
-	systrayMenuItemSelected(int32(cID))
+	systrayMenuItemSelected(uint32(cID))
 }

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -263,7 +263,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		menuItemId := int32(wParam)
 		// https://docs.microsoft.com/en-us/windows/win32/menurc/wm-command#menus
 		if menuItemId != -1 {
-			systrayMenuItemSelected(menuItemId)
+			systrayMenuItemSelected(uint32(wParam))
 		}
 	case WM_CLOSE:
 		pDestroyWindow.Call(uintptr(t.window))
@@ -918,8 +918,8 @@ func (item *MenuItem) SetTemplateIcon(templateIconBytes []byte, regularIconBytes
 	item.SetIcon(regularIconBytes)
 }
 
-func addSeparator(id int32) {
-	err := wt.addSeparatorMenuItem(uint32(id), 0)
+func addSeparator(id uint32) {
+	err := wt.addSeparatorMenuItem(id, 0)
 	if err != nil {
 		log.Errorf("Unable to addSeparator: %v", err)
 		return


### PR DESCRIPTION
To avoid confusing a menu item with id 0 from an nonexistent menu id

Fixes https://github.com/getlantern/systray/issues/167