### PR TITLE
fix SetTitle documentation

### DIFF
--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -35,7 +35,7 @@ func SetIcon(iconBytes []byte) {
 	C.setIcon(cstr, (C.int)(len(iconBytes)), false)
 }
 
-// SetTitle sets the systray title, only available on Mac.
+// SetTitle sets the systray title, only available on Mac and Linux.
 func SetTitle(title string) {
 	C.setTitle(C.CString(title))
 }

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -850,7 +850,7 @@ func SetTemplateIcon(templateIconBytes []byte, regularIconBytes []byte) {
 	SetIcon(regularIconBytes)
 }
 
-// SetTitle sets the systray title, only available on Mac.
+// SetTitle sets the systray title, only available on Mac and Linux.
 func SetTitle(title string) {
 	// do nothing
 }


### PR DESCRIPTION
SetTitle is available on both MacOS and [Linux](https://github.com/getlantern/systray/blob/master/systray_linux.c#L178).

- [x] Has existing documentation been updated?

Irrelevant:
~~- [ ] Do the tests pass? Consistently?~~
~~- [ ] Did this change improve test coverage?~~
~~- [ ] Has it been reviewed/approved by relevant teammates?~~
~~- [ ] Can it be QA’d in staging or something like staging?~~
~~- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.~~
~~- [ ] Do we know how we’re going to deploy this?~~
~~- [ ] Are we clear on what the support and maintenance impact is?~~
~~- [ ] Did you create new documentation? Is it accessible and in the right place?~~
~~- [ ] Have you logged tickets for related technical debt with the label “techdebt”?~~