### PR TITLE
Add checkbox support for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On Linux Mint, `libxapp-dev` is also required .
 
 To build `webview_example`, you also need to install `libwebkit2gtk-4.0-dev` and remove `webview_example/rsrc.syso` which is required on Windows.
 
-* Submenu and checked menu items are not yet implemented
+* Submenu items are not yet implemented
 
 
 ### Windows

--- a/example/main.go
+++ b/example/main.go
@@ -37,7 +37,7 @@ func onReady() {
 		systray.SetTitle("Awesome App")
 		systray.SetTooltip("Pretty awesome棒棒嗒")
 		mChange := systray.AddMenuItem("Change Me", "Change Me")
-		mChecked := systray.AddMenuItem("Unchecked", "Check Me")
+		mChecked := systray.AddMenuItemCheckbox("Unchecked", "Check Me", true)
 		mEnabled := systray.AddMenuItem("Enabled", "Enabled")
 		// Sets the icon of a menu item. Only available on Mac.
 		mEnabled.SetTemplateIcon(icon.Data, icon.Data)
@@ -46,7 +46,7 @@ func onReady() {
 
 		subMenuTop := systray.AddMenuItem("SubMenu", "SubMenu Test (top)")
 		subMenuMiddle := subMenuTop.AddSubMenuItem("SubMenu - Level 2", "SubMenu Test (middle)")
-		subMenuBottom := subMenuMiddle.AddSubMenuItem("SubMenu - Level 3", "SubMenu Test (bottom)")
+		subMenuBottom := subMenuMiddle.AddSubMenuItemCheckbox("SubMenu - Level 3", "SubMenu Test (bottom)", false)
 		subMenuBottom2 := subMenuMiddle.AddSubMenuItem("Panic!", "SubMenu Test (bottom)")
 
 		mUrl := systray.AddMenuItem("Open UI", "my home")

--- a/systray.h
+++ b/systray.h
@@ -10,7 +10,7 @@ void setIcon(const char* iconBytes, int length, bool template);
 void setMenuItemIcon(const char* iconBytes, int length, int menuId, bool template);
 void setTitle(char* title);
 void setTooltip(char* tooltip);
-void add_or_update_menu_item(int menuId, int parentMenuId, char* title, char* tooltip, short disabled, short checked);
+void add_or_update_menu_item(int menuId, int parentMenuId, char* title, char* tooltip, short disabled, short checked, short isCheckable);
 void add_separator(int menuId);
 void hide_menu_item(int menuId);
 void show_menu_item(int menuId);

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -266,7 +266,7 @@ void setTooltip(char* ctooltip) {
   runInMainThread(@selector(setTooltip:), (id)tooltip);
 }
 
-void add_or_update_menu_item(int menuId, int parentMenuId, char* title, char* tooltip, short disabled, short checked) {
+void add_or_update_menu_item(int menuId, int parentMenuId, char* title, char* tooltip, short disabled, short checked, short isCheckable) {
   MenuItem* item = [[MenuItem alloc] initWithId: menuId withParentMenuId: parentMenuId withTitle: title withTooltip: tooltip withDisabled: disabled withChecked: checked];
   free(title);
   free(tooltip);

--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -55,6 +55,10 @@ func addOrUpdateMenuItem(item *MenuItem) {
 	if item.checked {
 		checked = 1
 	}
+	var isCheckable C.short
+	if item.isCheckable {
+		isCheckable = 1
+	}
 	var parentID uint32 = 0
 	if item.parent != nil {
 		parentID = item.parent.id
@@ -66,6 +70,7 @@ func addOrUpdateMenuItem(item *MenuItem) {
 		C.CString(item.tooltip),
 		disabled,
 		checked,
+		isCheckable,
 	)
 }
 


### PR DESCRIPTION
Addresses #180 

I had to implement a new method to decide if we want a checkbox or a normal menu item in Linux. Otherwise, all items would have ugly checkboxes.

To avoid introducing a breaking change, I've decided to add a new method. OSX and Windows users can use the new method too, for a cleaner interface, but without any difference. In a new major version, we could make only checkbox menu items (un)checkable. But that would be a breaking change of course. :) 

What do you think?

![Screen-Capture_select-area_20201114175924.png](https://images.f-brinker.de/images/2020/11/14/Screen-Capture_select-area_20201114175924.png)