### PR TITLE
Add Title() and Tooltip() accessor functions to MenuItem

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -162,10 +162,20 @@ func (item *MenuItem) SetTitle(title string) {
 	item.update()
 }
 
+// Title returns the text displayed on a menu item
+func (item *MenuItem) Title() string {
+	return item.title
+}
+
 // SetTooltip set the tooltip to show when mouse hover
 func (item *MenuItem) SetTooltip(tooltip string) {
 	item.tooltip = tooltip
 	item.update()
+}
+
+// Tooltip returns the tooltip shown when mouse hover
+func (item *MenuItem) Tooltip() string {
+	return item.tooltip
 }
 
 // Disabled checks if the menu item is disabled


### PR DESCRIPTION
This adds public accessors to title and tooltip attributes of MenuItem object.

Rationale:
To be able to access title and tooltip attributes from client item's loop function without the need to store item's title or tooltip elsewhere.
