### PR TITLE
Fix delFromVisibleItems

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -667,7 +667,7 @@ func (t *winTray) delFromVisibleItems(parent, val uint32) {
 	visibleItems := t.visibleItems[parent]
 	for i, itemval := range visibleItems {
 		if val == itemval {
-			visibleItems = append(visibleItems[:i], visibleItems[i+1:]...)
+			t.visibleItems[parent] = append(visibleItems[:i], visibleItems[i+1:]...)
 			break
 		}
 	}


### PR DESCRIPTION
A bug introduced when adding submenu support for Windows made delFromVisibleItems not do anything. The practical consequence of this is that calling menuItem.Show() could result in the item showing up in the wrong place. Easy fix.

(Caught by the go linter.)