### PR TITLE
Create menu before calling onReady on Windows

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -254,11 +254,8 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		WM_ENDSESSION = 0x0016
 		WM_CLOSE      = 0x0010
 		WM_DESTROY    = 0x0002
-		WM_CREATE     = 0x0001
 	)
 	switch message {
-	case WM_CREATE:
-		systrayReady()
 	case WM_COMMAND:
 		menuItemId := int32(wParam)
 		// https://docs.microsoft.com/en-us/windows/win32/menurc/wm-command#menus
@@ -771,6 +768,7 @@ func registerSystray() {
 		return
 	}
 
+	systrayReady()
 }
 
 func nativeLoop() {


### PR DESCRIPTION
Since 40effd06092690205d8914a73cad2dfa5236243c, onReady was getting called before the menu setup was fully done, resulting in errors when AddMenuItem was called early in onReady.

As far as I can tell there's no point in waiting for WM_CREATE; that message gets generated as a side-effect of calling CreateWindowEx and doesn't mean anything of importance.

Fixes #164, fixes #158, fixes #148.

Edit: probably also fixes #197.