### PR TITLE
Add support for building with either libappindicator(legacy) or libay…

### DIFF
--- a/systray_buster_notwin.go
+++ b/systray_buster_notwin.go
@@ -1,0 +1,107 @@
+//go:build legacy
+// +build legacy
+
+package systray
+
+/*
+#cgo linux pkg-config: gtk+-3.0 appindicator3-0.1
+#cgo darwin CFLAGS: -DDARWIN -x objective-c -fobjc-arc
+#cgo darwin LDFLAGS: -framework Cocoa
+
+#include "systray.h"
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+func registerSystray() {
+	C.registerSystray()
+}
+
+func nativeLoop() {
+	C.nativeLoop()
+}
+
+func quit() {
+	C.quit()
+}
+
+// SetIcon sets the systray icon.
+// iconBytes should be the content of .ico for windows and .ico/.jpg/.png
+// for other platforms.
+func SetIcon(iconBytes []byte) {
+	cstr := (*C.char)(unsafe.Pointer(&iconBytes[0]))
+	C.setIcon(cstr, (C.int)(len(iconBytes)), false)
+}
+
+// SetTitle sets the systray title, only available on Mac and Linux.
+func SetTitle(title string) {
+	C.setTitle(C.CString(title))
+}
+
+// SetTooltip sets the systray tooltip to display on mouse hover of the tray icon,
+// only available on Mac and Windows.
+func SetTooltip(tooltip string) {
+	C.setTooltip(C.CString(tooltip))
+}
+
+func addOrUpdateMenuItem(item *MenuItem) {
+	var disabled C.short
+	if item.disabled {
+		disabled = 1
+	}
+	var checked C.short
+	if item.checked {
+		checked = 1
+	}
+	var isCheckable C.short
+	if item.isCheckable {
+		isCheckable = 1
+	}
+	var parentID uint32 = 0
+	if item.parent != nil {
+		parentID = item.parent.id
+	}
+	C.add_or_update_menu_item(
+		C.int(item.id),
+		C.int(parentID),
+		C.CString(item.title),
+		C.CString(item.tooltip),
+		disabled,
+		checked,
+		isCheckable,
+	)
+}
+
+func addSeparator(id uint32) {
+	C.add_separator(C.int(id))
+}
+
+func hideMenuItem(item *MenuItem) {
+	C.hide_menu_item(
+		C.int(item.id),
+	)
+}
+
+func showMenuItem(item *MenuItem) {
+	C.show_menu_item(
+		C.int(item.id),
+	)
+}
+
+//export systray_ready
+func systray_ready() {
+	systrayReady()
+}
+
+//export systray_on_exit
+func systray_on_exit() {
+	systrayExit()
+}
+
+//export systray_menu_item_selected
+func systray_menu_item_selected(cID C.int) {
+	systrayMenuItemSelected(uint32(cID))
+}

--- a/systray_linux.c
+++ b/systray_linux.c
@@ -2,7 +2,11 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
-#include <libappindicator/app-indicator.h>
+#if __has_include("libayatana-appindicator/app-indicator.h") && __has_include(<libayatana-appindicator/app-indicator.h>)
+	#include <libayatana-appindicator/app-indicator.h>
+#else
+	#include <libappindicator/app-indicator.h>
+#endif
 #include "systray.h"
 
 static AppIndicator *global_app_indicator;

--- a/systray_notwin.go
+++ b/systray_notwin.go
@@ -1,9 +1,10 @@
-// +build !windows
+//go:build !legacy
+// +build !legacy
 
 package systray
 
 /*
-#cgo linux pkg-config: gtk+-3.0 appindicator3-0.1
+#cgo linux pkg-config: gtk+-3.0 ayatana-appindicator3-0.1
 #cgo darwin CFLAGS: -DDARWIN -x objective-c -fobjc-arc
 #cgo darwin LDFLAGS: -framework Cocoa
 


### PR DESCRIPTION
…atana-appindicator(current)

This PR adds the ability to use either libappindicator or libayatana-appindicator on Linux by passing the optional `--tag` to `go build` "legacy." In order to do this cleanly I needed to move non-windows builds to their file-based conditional compilation locations(`*_notwin.go`) and use `legacy` as a negative tag. This allows the library to be used on newer and oldstable Debians and Ubuntus.

- [Yes] Do the tests pass? Consistently?
- [No] Did this change improve test coverage?
- [No] Has it been reviewed/approved by relevant teammates?
- [Yes] Can it be QA’d in staging or something like staging?
- [Yes ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ I suppose yeah it's a pretty small update] Do we know how we’re going to deploy this?
- [Yes] Are we clear on what the support and maintenance impact is?
- [No] Did you create new documentation? Is it accessible and in the right place?
- [No] Has existing documentation been updated?
- [No] Have you logged tickets for related technical debt with the label “techdebt”?