### PR TITLE
Support libayatana-appindicator on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,20 @@ The code under `webview_example` is to demostrate how it can co-exist with other
 
 ### Linux
 
-* Building apps requires gcc as well as the `gtk3` and `libappindicator3` development headers to be installed. For Debian or Ubuntu, you may install these using:
+* Building apps requires gcc as well as the `gtk3` and `libayatana-appindicator3` development headers to be installed. For Debian or Ubuntu, you may install these using:
 
 ```sh
-sudo apt-get install gcc libgtk-3-dev libappindicator3-dev
+sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev
 ```
 
-On Linux Mint, `libxapp-dev` is also required .
+On Linux Mint, `libxapp-dev` is also required.
+
+If you need to support the older `libappindicator3` library instead, you can pass the build flag `legacy_appindicator`
+when building. For example:
+
+```
+go build -tags=legacy_appindicator`
+```
 
 To build `webview_example`, you also need to install `libwebkit2gtk-4.0-dev` and remove `webview_example/rsrc.syso` which is required on Windows.
 

--- a/systray_linux.c
+++ b/systray_linux.c
@@ -2,7 +2,13 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
+
+#ifdef USE_LEGACY_APPINDICATOR
 #include <libappindicator/app-indicator.h>
+#else
+#include <libayatana-appindicator/app-indicator.h>
+#endif
+
 #include "systray.h"
 
 static AppIndicator *global_app_indicator;

--- a/systray_linux.go
+++ b/systray_linux.go
@@ -1,13 +1,5 @@
 package systray
 
-/*
-#cgo darwin CFLAGS: -DDARWIN -x objective-c -fobjc-arc
-#cgo darwin LDFLAGS: -framework Cocoa -framework WebKit
-
-#include "systray.h"
-*/
-import "C"
-
 // SetTemplateIcon sets the systray icon as a template icon (on macOS), falling back
 // to a regular icon on other platforms.
 // templateIconBytes and iconBytes should be the content of .ico for windows and

--- a/systray_linux_appindicator.go
+++ b/systray_linux_appindicator.go
@@ -1,0 +1,11 @@
+//go:build linux && legacy_appindicator
+
+package systray
+
+/*
+#cgo linux pkg-config: appindicator3-0.1
+#cgo linux CFLAGS: -DUSE_LEGACY_APPINDICATOR
+
+#include "systray.h"
+*/
+import "C"

--- a/systray_linux_ayatana.go
+++ b/systray_linux_ayatana.go
@@ -1,0 +1,10 @@
+//go:build linux && !legacy_appindicator
+
+package systray
+
+/*
+#cgo linux pkg-config: ayatana-appindicator3-0.1
+
+#include "systray.h"
+*/
+import "C"


### PR DESCRIPTION
This changes the default behavior to use the `libayatana-appindicator` library instead of the older `libappindicator`. If you need to link to `libappindicator`, you can use the build tag "legacy_appindicator":

```
    go build -tags=legacy_appindicator
```

In order to support both libraries, I basically just moved the C setup and includes into two separate files (`systray_linux_appindicator.go` and `systray_linux_ayatana.go`) guarded by the relevant build tags. While here I also cleaned up some stale/unused build tags that referenced Darwin (I'm guessing this was a copy/paste error from a long time ago).

This was inspired by #224, but is a bit simpler in its approach, I think.