### PR TITLE
Fix +build lines, remove extraneous pkg-config directive

### DIFF
--- a/systray_linux_appindicator.go
+++ b/systray_linux_appindicator.go
@@ -1,3 +1,4 @@
+// +build linux,legacy_appindicator
 //go:build linux && legacy_appindicator
 
 package systray

--- a/systray_linux_ayatana.go
+++ b/systray_linux_ayatana.go
@@ -1,3 +1,4 @@
+// +build linux,!legacy_appindicator
 //go:build linux && !legacy_appindicator
 
 package systray

--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -1,14 +1,9 @@
 // +build !windows
+// go:build !windows
 
 package systray
 
-/*
-#cgo linux pkg-config: gtk+-3.0 appindicator3-0.1
-#cgo darwin CFLAGS: -DDARWIN -x objective-c -fobjc-arc
-#cgo darwin LDFLAGS: -framework Cocoa
-
-#include "systray.h"
-*/
+// #include "systray.h"
 import "C"
 
 import (


### PR DESCRIPTION
This commit should make systray build on Ubuntu 20.04 and (hopefully) Debian 11 again. I fumbled the legacy "+build" tag syntax, apparently, and forgot to remove a pkg-config directive that unconditionally required libappindicator3 to be installed.

I've tested this in the following configurations:
- Ubuntu 21.10 using Go 1.17 with and without the `legacy_appindicator` build tag;
- Ubuntu 20.04 using Go 1.16.2 with and without the `legacy_appindicator` build tag;
- Ubuntu 20.04 using Go 1.13.8 with and without the `legacy_appindicator` build tag.

In addition, for each of the above, I tested that the build succeeded if only one of the two libraries (appindicator3 or libayatana-appindicator3) was installed.

Note to future self: it'd probably be a good idea to enable GitHub Actions for this repo.