### PR TITLE
Wrap setIcon NSImage ops within autoreleasepool pattern

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -237,10 +237,12 @@ void runInMainThread(SEL method, id object) {
 
 void setIcon(const char* iconBytes, int length, bool template) {
   NSData* buffer = [NSData dataWithBytes: iconBytes length:length];
-  NSImage *image = [[NSImage alloc] initWithData:buffer];
-  [image setSize:NSMakeSize(16, 16)];
-  image.template = template;
-  runInMainThread(@selector(setIcon:), (id)image);
+  @autoreleasepool {
+     NSImage *image = [[NSImage alloc] initWithData:buffer];
+     [image setSize:NSMakeSize(16, 16)];
+     image.template = template;
+     runInMainThread(@selector(setIcon:), (id)image);
+  }
 }
 
 void setMenuItemIcon(const char* iconBytes, int length, int menuId, bool template) {


### PR DESCRIPTION
This allows us to prevent memory leaks when calling setIcon many times due to state change

Is related to #135

see https://stackoverflow.com/a/25880106

