### PR TITLE
Fix notifyIconData

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -111,7 +111,7 @@ type notifyIconData struct {
 	Tip                        [128]uint16
 	State, StateMask           uint32
 	Info                       [256]uint16
-	Timeout, Version           uint32
+	UnionTimeoutVersion        uint32
 	InfoTitle                  [64]uint16
 	InfoFlags                  uint32
 	GuidItem                   windows.GUID


### PR DESCRIPTION
`uTimeout` and `uVersion` are defined as an union in the original structure, which should take only 4 bytes in the corresponding structure in Golang.

Is related to  #253