### PR TITLE
Allow adding separators to submenus

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -48,6 +48,7 @@ func onReady() {
 		subMenuTop := systray.AddMenuItem("SubMenuTop", "SubMenu Test (top)")
 		subMenuMiddle := subMenuTop.AddSubMenuItem("SubMenuMiddle", "SubMenu Test (middle)")
 		subMenuBottom := subMenuMiddle.AddSubMenuItemCheckbox("SubMenuBottom - Toggle Panic!", "SubMenu Test (bottom) - Hide/Show Panic!", false)
+		subMenuMiddle.AddSeparator()
 		subMenuBottom2 := subMenuMiddle.AddSubMenuItem("SubMenuBottom - Panic!", "SubMenu Test (bottom)")
 
 		mUrl := systray.AddMenuItem("Open UI", "my home")

--- a/systray.go
+++ b/systray.go
@@ -133,7 +133,12 @@ func AddMenuItemCheckbox(title string, tooltip string, checked bool) *MenuItem {
 
 // AddSeparator adds a separator bar to the menu
 func AddSeparator() {
-	addSeparator(atomic.AddUint32(&currentID, 1))
+	addSeparator(0)
+}
+
+// AddSeparator adds a separator bar to the submenu
+func (item *MenuItem) AddSeparator() {
+	addSeparator(item.id)
 }
 
 // AddSubMenuItem adds a nested sub-menu item with the designated title and tooltip.

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -187,14 +187,17 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void) add_separator:(NSNumber*) menuId
 {
+  if ([menuId intValue] == 0) {
+    [menu addItem: [NSMenuItem separatorItem]];
+    return;
+  }
+
   NSMenuItem* menuItem = find_menu_item(menu, menuId);
   if (menuItem != NULL) {
     if (menuItem.hasSubmenu) {
       [menuItem.submenu addItem: [NSMenuItem separatorItem]];
     }
-    return;
   }
-  [menu addItem: [NSMenuItem separatorItem]];
 }
 
 - (void) hide_menu_item:(NSNumber*) menuId

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -187,6 +187,13 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void) add_separator:(NSNumber*) menuId
 {
+  NSMenuItem* menuItem = find_menu_item(menu, menuId);
+  if (menuItem != NULL) {
+    if (menuItem.hasSubmenu) {
+      [menuItem.submenu addItem: [NSMenuItem separatorItem]];
+    }
+    return;
+  }
   [menu addItem: [NSMenuItem separatorItem]];
 }
 

--- a/systray_linux.c
+++ b/systray_linux.c
@@ -179,8 +179,16 @@ gboolean do_add_or_update_menu_item(gpointer data) {
 }
 
 gboolean do_add_separator(gpointer data) {
+	MenuItemInfo *mii = (MenuItemInfo*)data;
+	GtkMenuItem* menuItem = find_menu_by_id(mii->menu_id);
+	GtkWidget* menu = gtk_menu_item_get_submenu(menuItem);
+
+	if(menu == NULL) {
+		menu = global_tray_menu;
+	}
+
 	GtkWidget *separator = gtk_separator_menu_item_new();
-	gtk_menu_shell_append(GTK_MENU_SHELL(global_tray_menu), separator);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), separator);
 	gtk_widget_show(separator);
 	return FALSE;
 }

--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -1,5 +1,5 @@
+//go:build !windows
 // +build !windows
-// go:build !windows
 
 package systray
 
@@ -69,8 +69,8 @@ func addOrUpdateMenuItem(item *MenuItem) {
 	)
 }
 
-func addSeparator(id uint32) {
-	C.add_separator(C.int(id))
+func addSeparator(menuID uint32) {
+	C.add_separator(C.int(menuID))
 }
 
 func hideMenuItem(item *MenuItem) {


### PR DESCRIPTION
Fixes #170

Add implementation of separators in submenus for
mac, linux and windows.

Tested on:
- MacOS 14.7 (Sonoma) / amd64
- Kali linux (2020.4 rolling, kernel 5.9.0)  / amd64
- Windows 10