### PR TITLE
fix(windows): pre-multiply alpha when setting menu item icons to fix black background

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -23,6 +23,7 @@ var (
 	pCreateDIBSection       = g32.NewProc("CreateDIBSection")
 	pCreateCompatibleDC     = g32.NewProc("CreateCompatibleDC")
 	pDeleteDC               = g32.NewProc("DeleteDC")
+	pDeleteObject           = g32.NewProc("DeleteObject")
 	pSelectObject           = g32.NewProc("SelectObject")
 
 	k32              = windows.NewLazySystemDLL("Kernel32.dll")
@@ -788,15 +789,17 @@ func (t *winTray) iconToBitmap(hIcon windows.Handle) (windows.Handle, error) {
 	defer pSelectObject.Call(hMemDC, hOriginalBmp)
 	res, _, err := pDrawIconEx.Call(hMemDC, 0, 0, uintptr(hIcon), cx, cy, 0, uintptr(0), DI_NORMAL)
 	if res == 0 {
+		pDeleteObject.Call(hMemBmp)
 		return 0, err
 	}
 
 	if bits != nil {
-		pixels := (*[1 << 30]byte)(bits)[:cx*cy*4 : cx*cy*4]
-		// Pre-multiply alpha channel before creating HBITMAP
+		totalBytes := int(cx) * int(cy) * 4
+		pixels := (*[1 << 30]byte)(bits)[:totalBytes:totalBytes]
+		// Pre-multiply alpha channel in-place before returning/using the HBITMAP
 		for i := 0; i < len(pixels); i += 4 {
 			a := uint32(pixels[i+3])
-			pixels[i] = byte(uint32(pixels[i]) * a / 255)     // R
+			pixels[i] = byte(uint32(pixels[i]) * a / 255)   // R
 			pixels[i+1] = byte(uint32(pixels[i+1]) * a / 255) // G
 			pixels[i+2] = byte(uint32(pixels[i+2]) * a / 255) // B
 		}

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	g32                     = windows.NewLazySystemDLL("Gdi32.dll")
-	pCreateCompatibleBitmap = g32.NewProc("CreateCompatibleBitmap")
+	pCreateDIBSection       = g32.NewProc("CreateDIBSection")
 	pCreateCompatibleDC     = g32.NewProc("CreateCompatibleDC")
 	pDeleteDC               = g32.NewProc("DeleteDC")
 	pSelectObject           = g32.NewProc("SelectObject")
@@ -751,7 +751,36 @@ func (t *winTray) iconToBitmap(hIcon windows.Handle) (windows.Handle, error) {
 	defer pDeleteDC.Call(hMemDC)
 	cx, _, _ := pGetSystemMetrics.Call(SM_CXSMICON)
 	cy, _, _ := pGetSystemMetrics.Call(SM_CYSMICON)
-	hMemBmp, _, err := pCreateCompatibleBitmap.Call(hDC, cx, cy)
+
+	var bi struct {
+		Size          uint32
+		Width         int32
+		Height        int32
+		Planes        uint16
+		BitCount      uint16
+		Compression   uint32
+		SizeImage     uint32
+		XPelsPerMeter int32
+		YPelsPerMeter int32
+		ClrUsed       uint32
+		ClrImportant  uint32
+	}
+	bi.Size = uint32(unsafe.Sizeof(bi))
+	bi.Width = int32(cx)
+	bi.Height = int32(-cy) // top-down
+	bi.Planes = 1
+	bi.BitCount = 32
+	bi.Compression = 0 // BI_RGB
+
+	var bits unsafe.Pointer
+	hMemBmp, _, err := pCreateDIBSection.Call(
+		hDC,
+		uintptr(unsafe.Pointer(&bi)),
+		0, // DIB_RGB_COLORS
+		uintptr(unsafe.Pointer(&bits)),
+		0,
+		0,
+	)
 	if hMemBmp == 0 {
 		return 0, err
 	}
@@ -761,6 +790,18 @@ func (t *winTray) iconToBitmap(hIcon windows.Handle) (windows.Handle, error) {
 	if res == 0 {
 		return 0, err
 	}
+
+	if bits != nil {
+		pixels := (*[1 << 30]byte)(bits)[:cx*cy*4 : cx*cy*4]
+		// Pre-multiply alpha channel before creating HBITMAP
+		for i := 0; i < len(pixels); i += 4 {
+			a := uint32(pixels[i+3])
+			pixels[i] = byte(uint32(pixels[i]) * a / 255)     // R
+			pixels[i+1] = byte(uint32(pixels[i+1]) * a / 255) // G
+			pixels[i+2] = byte(uint32(pixels[i+2]) * a / 255) // B
+		}
+	}
+
 	return windows.Handle(hMemBmp), nil
 }
 


### PR DESCRIPTION
Fixes #267

## Problem
Menu item icons render with a black background on Windows 11 when the 
icon has transparent pixels. The tray icon itself renders correctly, 
and disabled menu items also render correctly — only enabled menu items 
are affected.

The root cause is that Windows GDI expects pre-multiplied alpha for 
HBITMAP objects used in menus. The previous code used 
CreateCompatibleBitmap which doesn't handle alpha, causing transparent 
pixels to render as black.

## Fix
Replaced CreateCompatibleBitmap with CreateDIBSection and added 
alpha pre-multiplication for each pixel before the bitmap is passed 
to SetMenuItemInfo:

- R = R * A / 255
- G = G * A / 255  
- B = B * A / 255

This matches the format Windows expects for alpha-blended menu bitmaps.

## Tested on
Windows 11 23H2