### PR TITLE
fix(windows): explicitly delete shell notify icon on teardown to prev…

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -262,6 +262,16 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 			systrayMenuItemSelected(uint32(wParam))
 		}
 	case WM_CLOSE:
+		// Explicitly remove the tray icon from the Shell before destroying the
+		// window. Without this, the icon can linger as a ghost in the taskbar
+		// notification area if WM_DESTROY is not processed before the process
+		// exits (e.g. when the message pump is already draining).
+		t.muNID.Lock()
+		if t.nid != nil {
+			t.nid.delete()
+			t.nid = nil
+		}
+		t.muNID.Unlock()
 		pDestroyWindow.Call(uintptr(t.window))
 		t.wcex.unregister()
 	case WM_DESTROY:
@@ -271,7 +281,10 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 	case WM_ENDSESSION:
 		t.muNID.Lock()
 		if t.nid != nil {
+			// Guard against double-delete: WM_CLOSE may have already removed
+			// the icon; only call delete() if nid is still set.
 			t.nid.delete()
+			t.nid = nil
 		}
 		t.muNID.Unlock()
 		systrayExit()

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -263,15 +263,17 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		}
 	case WM_CLOSE:
 		// Explicitly remove the tray icon from the Shell before destroying the
-		// window. Without this, the icon can linger as a ghost in the taskbar
-		// notification area if WM_DESTROY is not processed before the process
-		// exits (e.g. when the message pump is already draining).
+		// window. Under the lock, we pull a local reference and clear the pointer
+		// to safely invoke the Win32 deletion syscall outside the mutex context.
 		t.muNID.Lock()
-		if t.nid != nil {
-			t.nid.delete()
-			t.nid = nil
-		}
+		nidToClose := t.nid
+		t.nid = nil
 		t.muNID.Unlock()
+
+		if nidToClose != nil {
+			nidToClose.delete()
+		}
+
 		pDestroyWindow.Call(uintptr(t.window))
 		t.wcex.unregister()
 	case WM_DESTROY:
@@ -280,13 +282,13 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		fallthrough
 	case WM_ENDSESSION:
 		t.muNID.Lock()
-		if t.nid != nil {
-			// Guard against double-delete: WM_CLOSE may have already removed
-			// the icon; only call delete() if nid is still set.
-			t.nid.delete()
-			t.nid = nil
-		}
+		nidToEnd := t.nid
+		t.nid = nil
 		t.muNID.Unlock()
+
+		if nidToEnd != nil {
+			nidToEnd.delete()
+		}
 		systrayExit()
 	case t.wmSystrayMessage:
 		switch lParam {


### PR DESCRIPTION
Fixes #237

## Problem
When applications using this library exit on Windows, the icon often remains stagnant in the taskbar notification system tray as a "ghost" icon. It only disappears when a user explicitly hovers their mouse pointer over it, forcing the Windows Shell to realize the backing thread/process is dead.

## Fix
Intercepted `WM_CLOSE` and `WM_ENDSESSION` window messages inside `wndProc` to explicitly invoke `t.nid.delete()` (which triggers `Shell_NotifyIconW` with `NIM_DELETE`). 

- Wrapped the cleanup loop inside the `t.muNID` mutex lock.
- Reset `t.nid = nil` post-deletion to safely protect the execution path against double-deletion issues if multiple teardown signals fire sequentially.

## Tested on
Windows 11 (Go 1.26 verification build passes cleanly).